### PR TITLE
Added checkboxes in edit and add contact form for allow list and block list

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -220,3 +220,4 @@ env:
 
   # Uses yaml anchors to DRY - https://juju.is/docs/sdk/yaml-anchors-and-aliases
   - METAMASK_BUILD_TYPE_DEFAULT: *default
+  - EDITOR_URL: false

--- a/ui/components/app/contact-list/recipient-group/recipient-group.component.js
+++ b/ui/components/app/contact-list/recipient-group/recipient-group.component.js
@@ -2,12 +2,35 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Identicon from '../../../ui/identicon';
+import { Tag } from '../../../component-library/tag';
 import { ellipsify } from '../../../../pages/send/send.utils';
 
 function addressesEqual(address1, address2) {
   return String(address1).toLowerCase() === String(address2).toLowerCase();
 }
 
+function renderTags(tags) {
+  if (!tags) {
+    return null;
+  } else if (tags.includes('allowList')) {
+    return (
+      <Tag
+        label="AllowList"
+        labelProps={{ color: 'primary-inverse' }}
+        backgroundColor="success-default"
+      />
+    );
+  } else if (tags.includes('blockList')) {
+    return (
+      <Tag
+        label="BlockList"
+        labelProps={{ color: 'primary-inverse' }}
+        backgroundColor="error-default"
+      />
+    );
+  }
+  return undefined;
+}
 export default function RecipientGroup({
   label,
   items,
@@ -28,7 +51,7 @@ export default function RecipientGroup({
           {label}
         </div>
       )}
-      {items.map(({ address, name }) => (
+      {items.map(({ address, name, tags }) => (
         <div
           key={address}
           onClick={() => onSelect(address, name)}
@@ -55,6 +78,7 @@ export default function RecipientGroup({
               </div>
             )}
           </div>
+          {renderTags(tags)}
         </div>
       ))}
     </div>

--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.component.js
@@ -12,6 +12,15 @@ import {
   isValidHexAddress,
 } from '../../../../../shared/modules/hexstring-utils';
 import { INVALID_RECIPIENT_ADDRESS_ERROR } from '../../../send/send.constants';
+import CheckBox from '../../../../components/ui/check-box';
+import { Label, Text } from '../../../../components/component-library';
+import {
+  AlignItems,
+  FLEX_DIRECTION,
+  TextColor,
+  TextVariant,
+} from '../../../../helpers/constants/design-system';
+import Box from '../../../../components/ui/box';
 
 export default class AddContact extends PureComponent {
   static contextTypes = {
@@ -35,6 +44,7 @@ export default class AddContact extends PureComponent {
     ethAddress: '',
     error: '',
     input: '',
+    newTags: [],
   };
 
   constructor(props) {
@@ -77,6 +87,36 @@ export default class AddContact extends PureComponent {
     this.dValidate(input);
   };
 
+  addAllowList() {
+    this.state.newTags.length === 0
+      ? this.setState({ newTags: [...this.state.newTags, 'allowList'] })
+      : this.setState(
+          {
+            newTags: [],
+          },
+          () => {
+            this.setState({
+              newTags: [...this.state.newTags, 'allowList'],
+            });
+          },
+        );
+  }
+
+  addBlockList() {
+    this.state.newTags.length === 0
+      ? this.setState({ newTags: [...this.state.newTags, 'blockList'] })
+      : this.setState(
+          {
+            newTags: [],
+          },
+          () => {
+            this.setState({
+              newTags: [...this.state.newTags, 'blockList'],
+            });
+          },
+        );
+  }
+
   renderInput() {
     return (
       <DomainInput
@@ -101,7 +141,6 @@ export default class AddContact extends PureComponent {
     const { t } = this.context;
     const { history, addToAddressBook, domainError, domainResolution } =
       this.props;
-
     const errorToRender = domainError || this.state.error;
 
     return (
@@ -140,6 +179,61 @@ export default class AddContact extends PureComponent {
               </div>
             )}
           </div>
+          <Box
+            flexDirection={FLEX_DIRECTION.ROW}
+            alignItems={AlignItems.flexStart}
+            padding={6}
+            gap={2}
+          >
+            <CheckBox
+              value="allowList"
+              onClick={() => {
+                this.addAllowList();
+              }}
+              id="allow-list-checkbox"
+              checked={
+                this.state.newTags.length > 0 &&
+                this.state.newTags.includes('allowList')
+              }
+            />
+            <Label htmlFor="allow-list-checkbox">
+              <Text
+                variant={TextVariant.bodyMdBold}
+                as="span"
+                color={TextColor.successDefault}
+              >
+                Allow List
+              </Text>
+            </Label>
+          </Box>
+          <Box
+            flexDirection={FLEX_DIRECTION.ROW}
+            alignItems={AlignItems.flexStart}
+            paddingLeft={6}
+            paddingRight={6}
+            gap={2}
+          >
+            <CheckBox
+              id="block-list-checkbox"
+              value="blockList"
+              onClick={() => {
+                this.addBlockList();
+              }}
+              checked={
+                this.state.newTags.length > 0 &&
+                this.state.newTags.includes('blockList')
+              }
+            />
+            <Label htmlFor="block-list-checkbox">
+              <Text
+                variant={TextVariant.bodyMdBold}
+                as="span"
+                color={TextColor.errorDefault}
+              >
+                Block List
+              </Text>
+            </Label>
+          </Box>
         </div>
         <PageContainerFooter
           cancelText={this.context.t('cancel')}
@@ -152,6 +246,7 @@ export default class AddContact extends PureComponent {
             await addToAddressBook(
               domainResolution || this.state.ethAddress,
               this.state.newName,
+              this.state.newTags,
             );
             history.push(CONTACT_LIST_ROUTE);
           }}

--- a/ui/pages/settings/contact-list-tab/add-contact/add-contact.container.js
+++ b/ui/pages/settings/contact-list-tab/add-contact/add-contact.container.js
@@ -24,8 +24,8 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    addToAddressBook: (recipient, nickname) =>
-      dispatch(addToAddressBook(recipient, nickname)),
+    addToAddressBook: (recipient, nickname, tags) =>
+      dispatch(addToAddressBook(recipient, nickname, '', tags)),
     scanQrCode: () => dispatch(showQrScanner()),
     qrCodeDetected: (data) => dispatch(qrCodeDetected(data)),
     resetDomainResolution: () => dispatch(resetDomainResolution()),

--- a/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
+++ b/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.component.js
@@ -9,6 +9,15 @@ import {
   isBurnAddress,
   isValidHexAddress,
 } from '../../../../../shared/modules/hexstring-utils';
+import CheckBox from '../../../../components/ui/check-box';
+import { Label, Text } from '../../../../components/component-library';
+import {
+  AlignItems,
+  FLEX_DIRECTION,
+  TextColor,
+  TextVariant,
+} from '../../../../helpers/constants/design-system';
+import Box from '../../../../components/ui/box';
 
 export default class EditContact extends PureComponent {
   static contextTypes = {
@@ -25,19 +34,70 @@ export default class EditContact extends PureComponent {
     memo: PropTypes.string,
     viewRoute: PropTypes.string,
     listRoute: PropTypes.string,
+    tags: PropTypes.array,
   };
 
   static defaultProps = {
     name: '',
     memo: '',
+    tags: [],
   };
 
   state = {
     newName: this.props.name,
     newAddress: this.props.address,
     newMemo: this.props.memo,
+    newTags: this.props.tags,
     error: '',
   };
+
+  addAllowList() {
+    if (this.state.newTags.length === 0) {
+      this.setState({
+        newTags: [...this.state.newTags, 'allowList'],
+      });
+    }
+    if (this.state.newTags.length > 0) {
+      if (this.state.newTags.includes('blockList')) {
+        this.setState(
+          {
+            newTags: [],
+          },
+          () => {
+            this.setState({
+              newTags: [...this.state.newTags, 'allowList'],
+            });
+          },
+        );
+      } else {
+        this.setState({ newTags: [] });
+      }
+    }
+  }
+
+  addBlockList() {
+    if (this.state.newTags.length === 0) {
+      this.setState({
+        newTags: [...this.state.newTags, 'blockList'],
+      });
+    }
+    if (this.state.newTags.length > 0) {
+      if (this.state.newTags.includes('allowList')) {
+        this.setState(
+          {
+            newTags: [],
+          },
+          () => {
+            this.setState({
+              newTags: [...this.state.newTags, 'blockList'],
+            });
+          },
+        );
+      } else {
+        this.setState({ newTags: [] });
+      }
+    }
+  }
 
   render() {
     const { t } = this.context;
@@ -49,10 +109,10 @@ export default class EditContact extends PureComponent {
       listRoute,
       memo,
       name,
+      tags,
       removeFromAddressBook,
       viewRoute,
     } = this.props;
-
     if (!address) {
       return <Redirect to={{ pathname: listRoute }} />;
     }
@@ -130,6 +190,55 @@ export default class EditContact extends PureComponent {
               }}
             />
           </div>
+          <Box
+            flexDirection={FLEX_DIRECTION.ROW}
+            alignItems={AlignItems.flexStart}
+            padding={6}
+            gap={2}
+          >
+            <CheckBox
+              value={this.state.newTags}
+              onClick={() => {
+                this.addAllowList();
+              }}
+              id="allow-list-checkbox"
+              checked={this.state.newTags.includes('allowList')}
+            />
+            <Label htmlFor="allow-list-checkbox">
+              <Text
+                variant={TextVariant.bodyMdBold}
+                as="span"
+                color={TextColor.successDefault}
+              >
+                Allow List
+              </Text>
+            </Label>
+          </Box>
+          <Box
+            flexDirection={FLEX_DIRECTION.ROW}
+            alignItems={AlignItems.flexStart}
+            paddingLeft={6}
+            paddingRight={6}
+            gap={2}
+          >
+            <CheckBox
+              id="block-list-checkbox"
+              value={this.state.newTags}
+              onClick={() => {
+                this.addBlockList();
+              }}
+              checked={this.state.newTags.includes('blockList')}
+            />
+            <Label htmlFor="block-list-checkbox">
+              <Text
+                variant={TextVariant.bodyMdBold}
+                as="span"
+                color={TextColor.errorDefault}
+              >
+                Block List
+              </Text>
+            </Label>
+          </Box>
         </div>
         <PageContainerFooter
           cancelText={this.context.t('cancel')}
@@ -150,6 +259,7 @@ export default class EditContact extends PureComponent {
                   this.state.newAddress,
                   this.state.newName || name,
                   this.state.newMemo || memo,
+                  this.state.newTags || tags,
                 );
                 history.push(listRoute);
               } else {
@@ -161,6 +271,7 @@ export default class EditContact extends PureComponent {
                 address,
                 this.state.newName || name,
                 this.state.newMemo || memo,
+                this.state.newTags || tags,
               );
               history.push(listRoute);
             }
@@ -172,7 +283,8 @@ export default class EditContact extends PureComponent {
           disabled={
             (this.state.newName === name &&
               this.state.newAddress === address &&
-              this.state.newMemo === memo) ||
+              this.state.newMemo === memo &&
+              this.state.newTags === tags) ||
             !this.state.newName.trim()
           }
         />

--- a/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.container.js
+++ b/ui/pages/settings/contact-list-tab/edit-contact/edit-contact.container.js
@@ -24,8 +24,7 @@ const mapStateToProps = (state, ownProps) => {
 
   const contact =
     getAddressBookEntry(state, address) || state.metamask.identities[address];
-  const { memo, name } = contact || {};
-
+  const { memo, name, tags } = contact || {};
   const { chainId } = getProviderConfig(state);
 
   return {
@@ -33,6 +32,7 @@ const mapStateToProps = (state, ownProps) => {
     chainId,
     name,
     memo,
+    tags,
     viewRoute: CONTACT_VIEW_ROUTE,
     listRoute: CONTACT_LIST_ROUTE,
   };
@@ -40,8 +40,8 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    addToAddressBook: (recipient, nickname, memo) =>
-      dispatch(addToAddressBook(recipient, nickname, memo)),
+    addToAddressBook: (recipient, nickname, memo, tags) =>
+      dispatch(addToAddressBook(recipient, nickname, memo, tags)),
     removeFromAddressBook: (chainId, addressToRemove) =>
       dispatch(removeFromAddressBook(chainId, addressToRemove)),
   };


### PR DESCRIPTION
### Fixes #3 

Added
1. Checkbox to add in allowList and blockList in Add contacts
2. Checkbox to add in allowList and blockList in Edit contacts
3. Users can add contact without adding a label in add contacts form and if they want they can further update it in edit contacts
4. I can add the disable of the toggle but this seems a better UX since if I disable one checkbox while other is active. In that case, first I have to click the active checkbox to uncheck it and then I could select the other one.
5. Added a contact as neither on the allow or blacklist
6. Changed checkbox label to "Add to Allow List" (not covered in screencast)
7. Changed checkbox label to "Add to Block List" (not covered in screencast)


### Screencast


https://github.com/MetaMask/2023-hackathon-project/assets/39872794/3dcb4d8a-8272-4a68-835d-7e76690cd3d0



